### PR TITLE
Fix DRV8825 & DRV8880 enable & disable

### DIFF
--- a/src/BasicStepperDriver.h
+++ b/src/BasicStepperDriver.h
@@ -169,8 +169,8 @@ public:
     /*
      * Turn off/on motor to allow the motor to be moved by hand/hold the position in place
      */
-    void enable(void);
-    void disable(void);
+    virtual void enable(void);
+    virtual void disable(void);
     /*
      * Methods for non-blocking mode.
      * They use more code but allow doing other operations between impulses.

--- a/src/DRV8825.cpp
+++ b/src/DRV8825.cpp
@@ -47,21 +47,3 @@ size_t DRV8825::getMicrostepTableSize()
 short DRV8825::getMaxMicrostep(){
     return DRV8825::MAX_MICROSTEP;
 }
-
-/*
- * Enable/Disable the motor by setting a digital flag
- * for DRV8825
- * enable = HIGH
- * disable = LOW
- */
-void DRV8825::enable(void){
-    if IS_CONNECTED(enable_pin){
-        digitalWrite(enable_pin, HIGH);
-    }
-}
-
-void DRV8825::disable(void){
-    if IS_CONNECTED(enable_pin){
-        digitalWrite(enable_pin, LOW);
-    }
-}

--- a/src/DRV8825.h
+++ b/src/DRV8825.h
@@ -39,9 +39,5 @@ public:
     DRV8825(short steps, short dir_pin, short step_pin, short enable_pin);
     DRV8825(short steps, short dir_pin, short step_pin, short mode0_pin, short mode1_pin, short mode2_pin);
     DRV8825(short steps, short dir_pin, short step_pin, short enable_pin, short mode0_pin, short mode1_pin, short mode2_pin);
-    
-    // override enable/disable to change polarisation for DRV8825
-    void enable(void);
-    void disable(void);
 };
 #endif // DRV8825_H

--- a/src/DRV8880.cpp
+++ b/src/DRV8880.cpp
@@ -118,3 +118,21 @@ void DRV8880::setCurrent(short percent){
     digitalWrite(trq1, percent & 2);
     digitalWrite(trq0, percent & 1);
 }
+
+/*
+ * Enable/Disable the motor by setting a digital flag
+ * for DRV8880
+ * enable = HIGH
+ * disable = LOW
+ */
+void DRV8880::enable(void){
+    if IS_CONNECTED(enable_pin){
+        digitalWrite(enable_pin, HIGH);
+    }
+}
+
+void DRV8880::disable(void){
+    if IS_CONNECTED(enable_pin){
+        digitalWrite(enable_pin, LOW);
+    }
+}

--- a/src/DRV8880.h
+++ b/src/DRV8880.h
@@ -59,5 +59,9 @@ public:
      * current percent value must be 25, 50, 75 or 100.
      */
     void setCurrent(short percent=100);
+
+    // override enable/disable to change polarisation for DRV8880
+    void enable(void);
+    void disable(void);
 };
 #endif // DRV8880_H


### PR DESCRIPTION
Before this PR, if you used DRV8825 directly (not through MultiDriver)
and called enable(), the motor wouldn't move at all. According to the
DRV8825 datasheet, enable is active LOW, not HIGH. DRV8825.cpp shouldn't
override enable()/disable().

Coincidently, if you used DRV8825 through MultiDriver, the motor would
work normally, because the enable()/disable() functions weren't declared
virtual. MultiDriver would therefore call BasicStepperDriver::enable
(which correctly drives the pin LOW) instead of DRV8825:enable (which
drove the pin HIGH).

The first commit in this PR fixes both issues.

DRV8880, on the other hand, is active HIGH instead of LOW.  The second 
commit fixes the enabling of DRV8880. Fixes #51 