### PR TITLE
Use safer & faster min/max functions

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=StepperDriver
-version=1.4.0
+version=1.4.1
 author=Laurentiu Badea
 maintainer=Laurentiu Badea
 sentence=A4988, DRV8825 and generic two-pin stepper motor driver library.

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,3 +44,6 @@ board = teensylc
 [env:uno]
 board = uno
 platform = atmelavr
+
+[env:native]
+platform = native


### PR DESCRIPTION
Two issues here. First, the default min/max that this is dependening on uses
min/max as a macro. That means the `min` call was actually evaluating `sqrt`
and float cast twice, with a minor perf penalty (unless the optimizer catches
it).

Second, not all environments have min/max available in the
global namespace (particularly platformio's native env). This avoids that
implicit dependency. Therefore this fixes:

```
<path_here>/StepperDriver/src/BasicStepperDriver.cpp:141:25: error: use of undeclared identifier 'min'; did you mean 'fmin'?
```

The original purpose of this diff was the second issue, but researching other
people running into this made me realize the first issue. So I went down a
different fix.

Another fix is just use native c++'s std::min and std::max, but that gets into
various arduino-cli related compiler complications.