### PR TITLE
feat: Add PlatformIO support to devcontainer and Makefile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/base:jammy
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    python3-pip \
+    python3-venv \
+    udev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install -U platformio intelhex

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
 	"name": "Arduino & C++ Development",
-	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
 	"workspaceFolder": "/workspaces/StepperDriver",
 	"mounts": [
 		{
@@ -22,13 +25,15 @@
 				"ms-vscode.cpptools",
 				"ms-vscode.cpptools-themes",
 				"vsciot-vscode.vscode-arduino",
-				"eamodio.gitlens"
+				"eamodio.gitlens",
+				"platformio.platformio-ide"
 			],
 			"mcp": {
 				"servers": {}
 			}
 		}
 	},
+
 	"postCreateCommand": "sudo chown vscode /workspaces/StepperDriver/.arduino && make setup",
 	"remoteUser": "vscode"
 }

--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,7 @@ setup: $(ARDUINO_DIR)/arduino-cli
 	$(ARDUINO_CLI) core update-index
 	$(ARDUINO_CLI) core list
 
-.PHONY: clean %.hex all setup
+setup-pio: # Install PlatformIO and dependencies
+	pip3 install -U platformio intelhex
+
+.PHONY: clean %.hex all setup setup-pio


### PR DESCRIPTION
Refactors devcontainer to use a Dockerfile with pre-installed PlatformIO dependencies (platformio, intelhex, python3-pip). Adds a 'setup-pio' target to Makefile for host setup.