### PR TITLE
Fix LINEAR_SPEED running too fast at low rpm

### DIFF
--- a/src/BasicStepperDriver.cpp
+++ b/src/BasicStepperDriver.cpp
@@ -171,6 +171,10 @@ void BasicStepperDriver::startMove(long steps, long time){
         step_pulse = (1e+6)*0.676*sqrt(2.0f/profile.accel/microsteps);
         // Save cruise timing since we will no longer have the calculated target speed later
         cruise_step_pulse = 1e+6 / speed / microsteps;
+        // If target speed is reached within the first step (steps_to_cruise == 0),
+        // the accelerating state is never entered and c0 would be used for the entire
+        // move, which is faster than the cruise speed. Start at cruise speed instead.
+        step_pulse = stepperMax(step_pulse, cruise_step_pulse);
         break;
 
     case CONSTANT_SPEED:


### PR DESCRIPTION
Fixes #93

## Problem

In LINEAR_SPEED mode, when the target speed is low enough to be reached within a single step — `steps_to_cruise = microsteps * v^2 / (2 * accel)` truncates to 0 — the ACCELERATING state is unreachable (it requires `step_count <= steps_to_cruise`). As a result `step_pulse` is never snapped to `cruise_step_pulse`, and the entire move runs at the initial pulse c0 instead of the cruise pulse.

In the #93 UnitTest case (rpm=6, 200-step motor, microstep 1, accel=6000): c0 = 12,342 µs vs the correct cruise pulse of 50,000 µs — the motor ran ~4.05× faster than requested, matching the observed 2.46 s elapsed vs 10.0 s expected. The bug triggers whenever `rpm < (60/motor_steps)·√(2·accel/microsteps)` (~33 RPM for the UnitTest config), which is why 60 RPM and above passed.

## Fix

One line in `startMove()`: clamp the initial pulse to `cruise_step_pulse`. This is a no-op whenever `steps_to_cruise >= 1`, since c0 ≥ cruise pulse in that regime (c0/cruise ≥ 1.35 at the boundary), so normal accelerated moves are unaffected.

## Test results

**Functional** — host-side harness driving the actual library code (`startMove()`/`nextAction()` with a simulated `micros()` clock) through the UnitTest LINEAR_SPEED scenario, 200 steps, accel=decel=6000, microstep 1:

| rpm | expected (µs) | before (µs) | after (µs) |
|-----|--------------|-------------|------------|
| 6000 | 365,148 | 353,416 OK | 353,416 OK |
| 600 | 365,148 | 353,416 OK | 353,416 OK |
| 60 | 1,033,246 | 1,021,076 OK | 1,021,076 OK |
| 6 | 10,000,000 | 2,467,800 **FAIL (~4× fast)** | 9,999,400 OK (0.006% err) |

The "before" failure reproduces the #93 report (2,457,426 µs observed on a Feather M0) to within 0.5%.

**Build (UnitTest sketch, devcontainer)** — all pass with the fix:

| Environment | Toolchain | Result |
|-------------|-----------|--------|
| adafruit_feather_m0 (SAMD21, #93 platform) | pio run | SUCCESS |
| nodemcuv2 (ESP8266) | pio run | SUCCESS |
| esp32dev (ESP32) | pio run | SUCCESS |
| teensylc (Teensy LC) | pio run | SUCCESS |
| arduino:avr:uno | arduino-cli, `--warnings all` | SUCCESS, no warnings from `src/` |

## Performance impact

None — one comparison at move setup time, no change to the per-step hot path on any platform.

---
Agent: claude-fable-5 (Claude Code 2.1.153); max context and thinking level not exposed to the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)