### PR TITLE
Make step pulse timing per-driver instance members; add setMinStepPulse (fixes #136)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,11 +171,13 @@ All CI must pass before merging PRs.
 
 ### Timing Constraints
 - `step_high_min` / `step_low_min`: Minimum pulse durations (μs) - driver-specific.
-  These are instance members set in each driver's constructors; the base default is
-  1μs. Users can override at runtime with `setMinStepPulse(high_us, low_us)` (needed
-  on very fast MCUs like the Arduino Opta whose GPIO outpaces the driver).
-- `wakeup_time`: Time after enabling before movement (μs), instance member set in the
-  driver constructors (base default 0, floored to 2μs in `enable()`).
+  These are instance members; each driver defines a protected inline `initTiming()`
+  method in its header with the datasheet values and calls it from every constructor.
+  The base default is 1μs. Users can override at runtime with
+  `setMinStepPulse(high_us, low_us)` (needed on very fast MCUs like the Arduino Opta
+  whose GPIO outpaces the driver).
+- `wakeup_time`: Time after enabling before movement (μs), instance member set by the
+  driver's `initTiming()` (base default 0, floored to 2μs in `enable()`).
 - High RPM + high microstepping = limited by MCU speed
 
 ### Movement Modes
@@ -226,8 +228,9 @@ Before modifying timing-critical code paths:
 3. Inherit from appropriate base class (typically `A4988` or `DRV8825`)
 4. Override `getMaxMicrostep()` if different from parent
 5. Override `setMicrostep()` if pin configuration differs
-6. Update timing values if needed by assigning `step_high_min`, `step_low_min`, and
-   `wakeup_time` (instance members) in the driver's constructors
+6. Update timing values if needed by defining a protected inline `initTiming()` method
+   in the driver's header that assigns `step_high_min`, `step_low_min`, and
+   `wakeup_time` (instance members), and calling it from every constructor
 7. Add to `keywords.txt` for Arduino IDE highlighting
 8. Create an example sketch in `examples/`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,8 +170,12 @@ All CI must pass before merging PRs.
 - Must respect driver parameters such as microstep configuration, signal timing, etc. as documented in the driver chip datasheet
 
 ### Timing Constraints
-- `step_high_min` / `step_low_min`: Minimum pulse durations (μs) - driver-specific
-- `wakeup_time`: Time after enabling before movement (μs)
+- `step_high_min` / `step_low_min`: Minimum pulse durations (μs) - driver-specific.
+  These are instance members set in each driver's constructors; the base default is
+  1μs. Users can override at runtime with `setMinStepPulse(high_us, low_us)` (needed
+  on very fast MCUs like the Arduino Opta whose GPIO outpaces the driver).
+- `wakeup_time`: Time after enabling before movement (μs), instance member set in the
+  driver constructors (base default 0, floored to 2μs in `enable()`).
 - High RPM + high microstepping = limited by MCU speed
 
 ### Movement Modes
@@ -222,7 +226,8 @@ Before modifying timing-critical code paths:
 3. Inherit from appropriate base class (typically `A4988` or `DRV8825`)
 4. Override `getMaxMicrostep()` if different from parent
 5. Override `setMicrostep()` if pin configuration differs
-6. Update timing constants if needed (`step_high_min`, `wakeup_time`)
+6. Update timing values if needed by assigning `step_high_min`, `step_low_min`, and
+   `wakeup_time` (instance members) in the driver's constructors
 7. Add to `keywords.txt` for Arduino IDE highlighting
 8. Create an example sketch in `examples/`
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -16,6 +16,9 @@ move	KEYWORD2
 rotate	KEYWORD2
 setRPM	KEYWORD2
 getRPM	KEYWORD2
+setMinStepPulse	KEYWORD2
+getMinStepPulseHigh	KEYWORD2
+getMinStepPulseLow	KEYWORD2
 setCurrent	KEYWORD2
 enable	KEYWORD2
 disable	KEYWORD2

--- a/src/A4988.cpp
+++ b/src/A4988.cpp
@@ -19,13 +19,16 @@ const uint8_t A4988::MS_TABLE[] = {0b000, 0b001, 0b010, 0b011, 0b111};
  * Basic connection: only DIR, STEP are connected.
  * Microstepping controls should be hardwired.
  */
+// A4988 datasheet timing: STEP HIGH/LOW min 1us, wakeup 1000us
+#define A4988_SET_TIMING() do { step_high_min = 1; step_low_min = 1; wakeup_time = 1000; } while (0)
+
 A4988::A4988(short steps, short dir_pin, short step_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin)
-{}
+{ A4988_SET_TIMING(); }
 
 A4988::A4988(short steps, short dir_pin, short step_pin, short enable_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin)
-{}
+{ A4988_SET_TIMING(); }
 
 /*
  * Fully wired.
@@ -34,12 +37,12 @@ A4988::A4988(short steps, short dir_pin, short step_pin, short enable_pin)
 A4988::A4988(short steps, short dir_pin, short step_pin, short ms1_pin, short ms2_pin, short ms3_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin),
     ms1_pin(ms1_pin), ms2_pin(ms2_pin), ms3_pin(ms3_pin)
-{}
+{ A4988_SET_TIMING(); }
 
 A4988::A4988(short steps, short dir_pin, short step_pin, short enable_pin, short ms1_pin, short ms2_pin, short ms3_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin),
 ms1_pin(ms1_pin), ms2_pin(ms2_pin), ms3_pin(ms3_pin)
-{}
+{ A4988_SET_TIMING(); }
 
 void A4988::begin(float rpm, short microsteps){
     BasicStepperDriver::begin(rpm, microsteps);

--- a/src/A4988.cpp
+++ b/src/A4988.cpp
@@ -19,16 +19,13 @@ const uint8_t A4988::MS_TABLE[] = {0b000, 0b001, 0b010, 0b011, 0b111};
  * Basic connection: only DIR, STEP are connected.
  * Microstepping controls should be hardwired.
  */
-// A4988 datasheet timing: STEP HIGH/LOW min 1us, wakeup 1000us
-#define A4988_SET_TIMING() do { step_high_min = 1; step_low_min = 1; wakeup_time = 1000; } while (0)
-
 A4988::A4988(short steps, short dir_pin, short step_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin)
-{ A4988_SET_TIMING(); }
+{ initTiming(); }
 
 A4988::A4988(short steps, short dir_pin, short step_pin, short enable_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin)
-{ A4988_SET_TIMING(); }
+{ initTiming(); }
 
 /*
  * Fully wired.
@@ -37,12 +34,12 @@ A4988::A4988(short steps, short dir_pin, short step_pin, short enable_pin)
 A4988::A4988(short steps, short dir_pin, short step_pin, short ms1_pin, short ms2_pin, short ms3_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin),
     ms1_pin(ms1_pin), ms2_pin(ms2_pin), ms3_pin(ms3_pin)
-{ A4988_SET_TIMING(); }
+{ initTiming(); }
 
 A4988::A4988(short steps, short dir_pin, short step_pin, short enable_pin, short ms1_pin, short ms2_pin, short ms3_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin),
 ms1_pin(ms1_pin), ms2_pin(ms2_pin), ms3_pin(ms3_pin)
-{ A4988_SET_TIMING(); }
+{ initTiming(); }
 
 void A4988::begin(float rpm, short microsteps){
     BasicStepperDriver::begin(rpm, microsteps);

--- a/src/A4988.h
+++ b/src/A4988.h
@@ -18,12 +18,8 @@ protected:
     short ms1_pin = PIN_UNCONNECTED;
     short ms2_pin = PIN_UNCONNECTED;
     short ms3_pin = PIN_UNCONNECTED;
-    // tA STEP minimum, HIGH pulse width (1us)
-    static const int step_high_min = 1;
-    // tB STEP minimum, LOW pulse width (1us)
-    static const int step_low_min = 1;
-    // wakeup time, nSLEEP inactive to STEP (1000us)
-    static const int wakeup_time = 1000;
+    // Timing (set in constructors): tA STEP HIGH min 1us, tB STEP LOW min 1us,
+    // wakeup time nSLEEP inactive to STEP 1000us.
     // also 200ns between ENBL/DIR/MSx changes and STEP HIGH
 
     // Get the microstep table

--- a/src/A4988.h
+++ b/src/A4988.h
@@ -18,8 +18,15 @@ protected:
     short ms1_pin = PIN_UNCONNECTED;
     short ms2_pin = PIN_UNCONNECTED;
     short ms3_pin = PIN_UNCONNECTED;
-    // Timing (set in constructors): tA STEP HIGH min 1us, tB STEP LOW min 1us,
-    // wakeup time nSLEEP inactive to STEP 1000us.
+    // Set timing requirements from A4988 datasheet
+    void initTiming(){
+        // tA STEP HIGH pulse duration, min value (1us)
+        step_high_min = 1;
+        // tB STEP LOW pulse duration, min value (1us)
+        step_low_min = 1;
+        // tWAKE wakeup time, nSLEEP inactive to STEP (1000us)
+        wakeup_time = 1000;
+    }
     // also 200ns between ENBL/DIR/MSx changes and STEP HIGH
 
     // Get the microstep table

--- a/src/BasicStepperDriver.cpp
+++ b/src/BasicStepperDriver.cpp
@@ -342,7 +342,9 @@ long BasicStepperDriver::nextAction(void){
         // account for calcStepPulse() execution time; sets ceiling for max rpm on slower MCUs
         last_action_end = micros();
         m = last_action_end - m;
-        next_action_interval = (pulse > m) ? pulse - m : 1;
+        // floor the STEP LOW interval at step_low_min (datasheet tWL) instead of 1us
+        unsigned low_min = (unsigned)step_low_min;
+        next_action_interval = (pulse > m + low_min) ? pulse - m : low_min;
     } else {
         // end of move
         last_action_end = 0;
@@ -380,7 +382,9 @@ void BasicStepperDriver::enable(void){
     if IS_CONNECTED(enable_pin){
         digitalWrite(enable_pin, enable_active_state);
     };
-    delayMicros(2);
+    // wait the driver's wakeup time (datasheet tWAKE) before stepping,
+    // but at least 2us as the base default wakeup_time is 0
+    delayMicros(stepperMax((short)2, wakeup_time));
 }
 
 void BasicStepperDriver::disable(void){

--- a/src/BasicStepperDriver.h
+++ b/src/BasicStepperDriver.h
@@ -74,11 +74,13 @@ protected:
     // current microstep level (1,2,4,8,...), must be < getMaxMicrostep()
     short microsteps = 1;
     // tWH(STEP) pulse duration, STEP high, min value (us)
-    static const int step_high_min = 1;
+    // Instance members (not static const) so derived drivers can set datasheet
+    // values in their constructors and users can override via setMinStepPulse().
+    short step_high_min = 1;
     // tWL(STEP) pulse duration, STEP low, min value (us)
-    static const int step_low_min = 1;
+    short step_low_min = 1;
     // tWAKE wakeup time, nSLEEP inactive to STEP (us)
-    static const int wakeup_time = 0;
+    short wakeup_time = 0;
 
     float rpm = 0;
 
@@ -136,6 +138,22 @@ public:
     };
     float getCurrentRPM(void){
         return (60.0*1000000L / step_pulse / microsteps / motor_steps);
+    }
+    /*
+     * Set minimum STEP pulse HIGH and LOW durations (microseconds).
+     * Useful on fast MCUs (e.g. Arduino Opta) whose GPIO toggles faster than
+     * the driver can register the default 1us pulses. See issue #136.
+     */
+    void setMinStepPulse(short high_us, short low_us){
+        step_high_min = (high_us > 0) ? high_us : 0;
+        // LOW interval must stay >= 1: nextAction() returning 0 means move complete
+        step_low_min = (low_us > 1) ? low_us : 1;
+    }
+    short getMinStepPulseHigh(void){
+        return step_high_min;
+    }
+    short getMinStepPulseLow(void){
+        return step_low_min;
     }
     /*
      * Set speed profile - CONSTANT_SPEED, LINEAR_SPEED (accelerated)

--- a/src/DRV8825.cpp
+++ b/src/DRV8825.cpp
@@ -15,27 +15,24 @@
  */
 const uint8_t DRV8825::MS_TABLE[] = {0b000, 0b001, 0b010, 0b011, 0b100, 0b111};
 
-// DRV8825 datasheet timing: STEP HIGH/LOW min 1.9us -> 2, wakeup 1700us
-#define DRV8825_SET_TIMING() do { step_high_min = 2; step_low_min = 2; wakeup_time = 1700; } while (0)
-
 DRV8825::DRV8825(short steps, short dir_pin, short step_pin)
 :A4988(steps, dir_pin, step_pin)
-{ DRV8825_SET_TIMING(); }
+{ initTiming(); }
 
 DRV8825::DRV8825(short steps, short dir_pin, short step_pin, short enable_pin)
 :A4988(steps, dir_pin, step_pin, enable_pin)
-{ DRV8825_SET_TIMING(); }
+{ initTiming(); }
 
 /*
  * A4988-DRV8825 Compatibility map: MS1-MODE0, MS2-MODE1, MS3-MODE2
  */
 DRV8825::DRV8825(short steps, short dir_pin, short step_pin, short mode0_pin, short mode1_pin, short mode2_pin)
 :A4988(steps, dir_pin, step_pin, mode0_pin, mode1_pin, mode2_pin)
-{ DRV8825_SET_TIMING(); }
+{ initTiming(); }
 
 DRV8825::DRV8825(short steps, short dir_pin, short step_pin, short enable_pin, short mode0_pin, short mode1_pin, short mode2_pin)
 :A4988(steps, dir_pin, step_pin, enable_pin, mode0_pin, mode1_pin, mode2_pin)
-{ DRV8825_SET_TIMING(); }
+{ initTiming(); }
 
 const uint8_t* DRV8825::getMicrostepTable()
 {

--- a/src/DRV8825.cpp
+++ b/src/DRV8825.cpp
@@ -15,24 +15,27 @@
  */
 const uint8_t DRV8825::MS_TABLE[] = {0b000, 0b001, 0b010, 0b011, 0b100, 0b111};
 
+// DRV8825 datasheet timing: STEP HIGH/LOW min 1.9us -> 2, wakeup 1700us
+#define DRV8825_SET_TIMING() do { step_high_min = 2; step_low_min = 2; wakeup_time = 1700; } while (0)
+
 DRV8825::DRV8825(short steps, short dir_pin, short step_pin)
 :A4988(steps, dir_pin, step_pin)
-{}
+{ DRV8825_SET_TIMING(); }
 
 DRV8825::DRV8825(short steps, short dir_pin, short step_pin, short enable_pin)
 :A4988(steps, dir_pin, step_pin, enable_pin)
-{}
+{ DRV8825_SET_TIMING(); }
 
 /*
  * A4988-DRV8825 Compatibility map: MS1-MODE0, MS2-MODE1, MS3-MODE2
  */
 DRV8825::DRV8825(short steps, short dir_pin, short step_pin, short mode0_pin, short mode1_pin, short mode2_pin)
 :A4988(steps, dir_pin, step_pin, mode0_pin, mode1_pin, mode2_pin)
-{}
+{ DRV8825_SET_TIMING(); }
 
 DRV8825::DRV8825(short steps, short dir_pin, short step_pin, short enable_pin, short mode0_pin, short mode1_pin, short mode2_pin)
 :A4988(steps, dir_pin, step_pin, enable_pin, mode0_pin, mode1_pin, mode2_pin)
-{}
+{ DRV8825_SET_TIMING(); }
 
 const uint8_t* DRV8825::getMicrostepTable()
 {

--- a/src/DRV8825.h
+++ b/src/DRV8825.h
@@ -15,12 +15,8 @@
 class DRV8825 : public A4988 {
 protected:
     static const uint8_t MS_TABLE[];
-    // tWH(STEP) pulse duration, STEP high, min value (1.9us)
-    static const int step_high_min = 2;
-    // tWL(STEP) pulse duration, STEP low, min value (1.9us)
-    static const int step_low_min = 2;
-    // tWAKE wakeup time, nSLEEP inactive to STEP (1000us)
-    static const int wakeup_time = 1700;
+    // Timing (set in constructors): tWH(STEP) HIGH min 1.9us -> 2,
+    // tWL(STEP) LOW min 1.9us -> 2, tWAKE wakeup time 1700us.
     // also 650ns between ENBL/DIR/MODEx changes and STEP HIGH
 
     // Get the microstep table

--- a/src/DRV8825.h
+++ b/src/DRV8825.h
@@ -15,8 +15,15 @@
 class DRV8825 : public A4988 {
 protected:
     static const uint8_t MS_TABLE[];
-    // Timing (set in constructors): tWH(STEP) HIGH min 1.9us -> 2,
-    // tWL(STEP) LOW min 1.9us -> 2, tWAKE wakeup time 1700us.
+    // Set timing requirements from DRV8825 datasheet
+    void initTiming(){
+        // tWH(STEP) pulse duration, STEP high, min value (1.9us)
+        step_high_min = 2;
+        // tWL(STEP) pulse duration, STEP low, min value (1.9us)
+        step_low_min = 2;
+        // tWAKE wakeup time, nSLEEP inactive to STEP (1700us)
+        wakeup_time = 1700;
+    }
     // also 650ns between ENBL/DIR/MODEx changes and STEP HIGH
 
     // Get the microstep table

--- a/src/DRV8834.cpp
+++ b/src/DRV8834.cpp
@@ -13,27 +13,24 @@
  * Basic connection: only DIR, STEP are connected.
  * Microstepping controls should be hardwired.
  */
-// DRV8834 datasheet timing: STEP HIGH/LOW min 1.9us -> 2, wakeup 1000us
-#define DRV8834_SET_TIMING() do { step_high_min = 2; step_low_min = 2; wakeup_time = 1000; } while (0)
-
 DRV8834::DRV8834(short steps, short dir_pin, short step_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin)
-{ DRV8834_SET_TIMING(); }
+{ initTiming(); }
 
 DRV8834::DRV8834(short steps, short dir_pin, short step_pin, short enable_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin)
-{ DRV8834_SET_TIMING(); }
+{ initTiming(); }
 
 /*
  * Fully wired. All the necessary control pins for DRV8834 are connected.
  */
 DRV8834::DRV8834(short steps, short dir_pin, short step_pin, short m0_pin, short m1_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin), m0_pin(m0_pin), m1_pin(m1_pin)
-{ DRV8834_SET_TIMING(); }
+{ initTiming(); }
 
 DRV8834::DRV8834(short steps, short dir_pin, short step_pin, short enable_pin, short m0_pin, short m1_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin), m0_pin(m0_pin), m1_pin(m1_pin)
-{ DRV8834_SET_TIMING(); }
+{ initTiming(); }
 
 /*
  * Set microstepping mode (1:divisor)

--- a/src/DRV8834.cpp
+++ b/src/DRV8834.cpp
@@ -13,24 +13,27 @@
  * Basic connection: only DIR, STEP are connected.
  * Microstepping controls should be hardwired.
  */
+// DRV8834 datasheet timing: STEP HIGH/LOW min 1.9us -> 2, wakeup 1000us
+#define DRV8834_SET_TIMING() do { step_high_min = 2; step_low_min = 2; wakeup_time = 1000; } while (0)
+
 DRV8834::DRV8834(short steps, short dir_pin, short step_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin)
-{}
+{ DRV8834_SET_TIMING(); }
 
 DRV8834::DRV8834(short steps, short dir_pin, short step_pin, short enable_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin)
-{}
+{ DRV8834_SET_TIMING(); }
 
 /*
  * Fully wired. All the necessary control pins for DRV8834 are connected.
  */
 DRV8834::DRV8834(short steps, short dir_pin, short step_pin, short m0_pin, short m1_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin), m0_pin(m0_pin), m1_pin(m1_pin)
-{}
+{ DRV8834_SET_TIMING(); }
 
 DRV8834::DRV8834(short steps, short dir_pin, short step_pin, short enable_pin, short m0_pin, short m1_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin), m0_pin(m0_pin), m1_pin(m1_pin)
-{}
+{ DRV8834_SET_TIMING(); }
 
 /*
  * Set microstepping mode (1:divisor)

--- a/src/DRV8834.h
+++ b/src/DRV8834.h
@@ -16,12 +16,8 @@ class DRV8834 : public BasicStepperDriver {
 protected:
     short m0_pin = PIN_UNCONNECTED;
     short m1_pin = PIN_UNCONNECTED;
-    // tWH(STEP) pulse duration, STEP high, min value (1.9us)
-    static const int step_high_min = 2;
-    // tWL(STEP) pulse duration, STEP low, min value (1.9us)
-    static const int step_low_min = 2;
-    // tWAKE wakeup time, nSLEEP inactive to STEP (1000us)
-    static const int wakeup_time = 1000;
+    // Timing (set in constructors): tWH(STEP) HIGH min 1.9us -> 2,
+    // tWL(STEP) LOW min 1.9us -> 2, tWAKE wakeup time 1000us.
     // also 200ns between ENBL/DIR/Mx changes and STEP HIGH
 
     // Get max microsteps supported by the device

--- a/src/DRV8834.h
+++ b/src/DRV8834.h
@@ -16,8 +16,15 @@ class DRV8834 : public BasicStepperDriver {
 protected:
     short m0_pin = PIN_UNCONNECTED;
     short m1_pin = PIN_UNCONNECTED;
-    // Timing (set in constructors): tWH(STEP) HIGH min 1.9us -> 2,
-    // tWL(STEP) LOW min 1.9us -> 2, tWAKE wakeup time 1000us.
+    // Set timing requirements from DRV8834 datasheet
+    void initTiming(){
+        // tWH(STEP) pulse duration, STEP high, min value (1.9us)
+        step_high_min = 2;
+        // tWL(STEP) pulse duration, STEP low, min value (1.9us)
+        step_low_min = 2;
+        // tWAKE wakeup time, nSLEEP inactive to STEP (1000us)
+        wakeup_time = 1000;
+    }
     // also 200ns between ENBL/DIR/Mx changes and STEP HIGH
 
     // Get max microsteps supported by the device

--- a/src/DRV8880.cpp
+++ b/src/DRV8880.cpp
@@ -12,36 +12,32 @@
  * Basic connection: only DIR, STEP are connected.
  * Microstepping controls should be hardwired.
  */
-// DRV8880 datasheet timing: STEP HIGH/LOW min 0.47us -> 1 (rounded up; 0 could
-// produce sub-datasheet pulses on fast ARM boards), wakeup 1500us
-#define DRV8880_SET_TIMING() do { step_high_min = 1; step_low_min = 1; wakeup_time = 1500; } while (0)
-
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin)
-{ DRV8880_SET_TIMING(); }
+{ initTiming(); }
 
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short enable_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin)
-{ DRV8880_SET_TIMING(); }
+{ initTiming(); }
 
 /*
  * Fully wired. All the necessary control pins for DRV8880 are connected.
  */
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short m0, short m1)
 :BasicStepperDriver(steps, dir_pin, step_pin), m0(m0), m1(m1)
-{ DRV8880_SET_TIMING(); }
+{ initTiming(); }
 
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short enable_pin, short m0, short m1)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin), m0(m0), m1(m1)
-{ DRV8880_SET_TIMING(); }
+{ initTiming(); }
 
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short m0, short m1, short trq0, short trq1)
 :BasicStepperDriver(steps, dir_pin, step_pin), m0(m0), m1(m1), trq0(trq0), trq1(trq1)
-{ DRV8880_SET_TIMING(); }
+{ initTiming(); }
 
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short enable_pin, short m0, short m1, short trq0, short trq1)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin), m0(m0), m1(m1), trq0(trq0), trq1(trq1)
-{ DRV8880_SET_TIMING(); }
+{ initTiming(); }
 
 void DRV8880::begin(float rpm, short microsteps){
     BasicStepperDriver::begin(rpm, microsteps);

--- a/src/DRV8880.cpp
+++ b/src/DRV8880.cpp
@@ -12,32 +12,36 @@
  * Basic connection: only DIR, STEP are connected.
  * Microstepping controls should be hardwired.
  */
+// DRV8880 datasheet timing: STEP HIGH/LOW min 0.47us -> 1 (rounded up; 0 could
+// produce sub-datasheet pulses on fast ARM boards), wakeup 1500us
+#define DRV8880_SET_TIMING() do { step_high_min = 1; step_low_min = 1; wakeup_time = 1500; } while (0)
+
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin)
-{}
+{ DRV8880_SET_TIMING(); }
 
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short enable_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin)
-{}
+{ DRV8880_SET_TIMING(); }
 
 /*
  * Fully wired. All the necessary control pins for DRV8880 are connected.
  */
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short m0, short m1)
 :BasicStepperDriver(steps, dir_pin, step_pin), m0(m0), m1(m1)
-{}
+{ DRV8880_SET_TIMING(); }
 
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short enable_pin, short m0, short m1)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin), m0(m0), m1(m1)
-{}
+{ DRV8880_SET_TIMING(); }
 
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short m0, short m1, short trq0, short trq1)
 :BasicStepperDriver(steps, dir_pin, step_pin), m0(m0), m1(m1), trq0(trq0), trq1(trq1)
-{}
+{ DRV8880_SET_TIMING(); }
 
 DRV8880::DRV8880(short steps, short dir_pin, short step_pin, short enable_pin, short m0, short m1, short trq0, short trq1)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin), m0(m0), m1(m1), trq0(trq0), trq1(trq1)
-{}
+{ DRV8880_SET_TIMING(); }
 
 void DRV8880::begin(float rpm, short microsteps){
     BasicStepperDriver::begin(rpm, microsteps);

--- a/src/DRV8880.h
+++ b/src/DRV8880.h
@@ -17,9 +17,19 @@ protected:
     short m1 = PIN_UNCONNECTED;
     short trq0 = PIN_UNCONNECTED;
     short trq1 = PIN_UNCONNECTED;
-    // Timing (set in constructors): tWH(STEP) HIGH min 0.47us -> 1,
-    // tWL(STEP) LOW min 0.47us -> 1 (rounded up; a 0 delay could produce
-    // sub-datasheet pulses on fast ARM boards), tWAKE wakeup time 1500us.
+    // Set timing requirements from DRV8880 datasheet
+    void initTiming(){
+        // tWH(STEP) pulse duration, STEP high, min value (0.47us -> 1;
+        // rounded up because a 0 delay could produce sub-datasheet pulses
+        // on fast ARM boards)
+        step_high_min = 1;
+        // tWL(STEP) pulse duration, STEP low, min value (0.47us -> 1;
+        // rounded up because a 0 delay could produce sub-datasheet pulses
+        // on fast ARM boards)
+        step_low_min = 1;
+        // tWAKE wakeup time, nSLEEP inactive to STEP (1500us)
+        wakeup_time = 1500;
+    }
     // also 200ns between ENBL/DIR/Mx changes and STEP HIGH
 
     // Get max microsteps supported by the device

--- a/src/DRV8880.h
+++ b/src/DRV8880.h
@@ -17,12 +17,9 @@ protected:
     short m1 = PIN_UNCONNECTED;
     short trq0 = PIN_UNCONNECTED;
     short trq1 = PIN_UNCONNECTED;
-    // tWH(STEP) pulse duration, STEP high, min value
-    static const int step_high_min = 0;   // 0.47us
-    // tWL(STEP) pulse duration, STEP low, min value
-    static const int step_low_min = 0;    // 0.47us
-    // tWAKE wakeup time, nSLEEP inactive to STEP
-    static const int wakeup_time = 1500;
+    // Timing (set in constructors): tWH(STEP) HIGH min 0.47us -> 1,
+    // tWL(STEP) LOW min 0.47us -> 1 (rounded up; a 0 delay could produce
+    // sub-datasheet pulses on fast ARM boards), tWAKE wakeup time 1500us.
     // also 200ns between ENBL/DIR/Mx changes and STEP HIGH
 
     // Get max microsteps supported by the device

--- a/src/TMC2100.cpp
+++ b/src/TMC2100.cpp
@@ -10,13 +10,16 @@
  * Basic connection: only DIR, STEP are connected.
  * Microstepping controls should be hardwired.
  */
+// TMC2100 datasheet timing: STEP HIGH/LOW min 1us, wakeup 1000us
+#define TMC2100_SET_TIMING() do { step_high_min = 1; step_low_min = 1; wakeup_time = 1000; } while (0)
+
 TMC2100::TMC2100(short steps, short dir_pin, short step_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin)
-{}
+{ TMC2100_SET_TIMING(); }
 
 TMC2100::TMC2100(short steps, short dir_pin, short step_pin, short enable_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin)
-{}
+{ TMC2100_SET_TIMING(); }
 
 /*
  * Fully wired.
@@ -25,12 +28,12 @@ TMC2100::TMC2100(short steps, short dir_pin, short step_pin, short enable_pin)
 TMC2100::TMC2100(short steps, short dir_pin, short step_pin, short cf1_pin, short cf2_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin),
     cf1_pin(cf1_pin), cf2_pin(cf2_pin)
-{}
+{ TMC2100_SET_TIMING(); }
 
 TMC2100::TMC2100(short steps, short dir_pin, short step_pin, short enable_pin, short cf1_pin, short cf2_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin),
 cf1_pin(cf1_pin), cf2_pin(cf2_pin)
-{}
+{ TMC2100_SET_TIMING(); }
 
 void TMC2100::begin(float rpm, short microsteps){
     BasicStepperDriver::begin(rpm, microsteps);

--- a/src/TMC2100.cpp
+++ b/src/TMC2100.cpp
@@ -10,16 +10,13 @@
  * Basic connection: only DIR, STEP are connected.
  * Microstepping controls should be hardwired.
  */
-// TMC2100 datasheet timing: STEP HIGH/LOW min 1us, wakeup 1000us
-#define TMC2100_SET_TIMING() do { step_high_min = 1; step_low_min = 1; wakeup_time = 1000; } while (0)
-
 TMC2100::TMC2100(short steps, short dir_pin, short step_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin)
-{ TMC2100_SET_TIMING(); }
+{ initTiming(); }
 
 TMC2100::TMC2100(short steps, short dir_pin, short step_pin, short enable_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin)
-{ TMC2100_SET_TIMING(); }
+{ initTiming(); }
 
 /*
  * Fully wired.
@@ -28,12 +25,12 @@ TMC2100::TMC2100(short steps, short dir_pin, short step_pin, short enable_pin)
 TMC2100::TMC2100(short steps, short dir_pin, short step_pin, short cf1_pin, short cf2_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin),
     cf1_pin(cf1_pin), cf2_pin(cf2_pin)
-{ TMC2100_SET_TIMING(); }
+{ initTiming(); }
 
 TMC2100::TMC2100(short steps, short dir_pin, short step_pin, short enable_pin, short cf1_pin, short cf2_pin)
 :BasicStepperDriver(steps, dir_pin, step_pin, enable_pin),
 cf1_pin(cf1_pin), cf2_pin(cf2_pin)
-{ TMC2100_SET_TIMING(); }
+{ initTiming(); }
 
 void TMC2100::begin(float rpm, short microsteps){
     BasicStepperDriver::begin(rpm, microsteps);

--- a/src/TMC2100.h
+++ b/src/TMC2100.h
@@ -13,12 +13,8 @@ class TMC2100 : public BasicStepperDriver {
 protected:
     short cf1_pin = PIN_UNCONNECTED;
     short cf2_pin = PIN_UNCONNECTED;
-    // tA STEP minimum, HIGH pulse width (1us)
-    static const int step_high_min = 1;
-    // tB STEP minimum, LOW pulse width (1us)
-    static const int step_low_min = 1;
-    // wakeup time, nSLEEP inactive to STEP (1000us)
-    static const int wakeup_time = 1000;
+    // Timing (set in constructors): tA STEP HIGH min 1us, tB STEP LOW min 1us,
+    // wakeup time nSLEEP inactive to STEP 1000us.
 
     // Get max microsteps supported by the device
     short getMaxMicrostep() override;

--- a/src/TMC2100.h
+++ b/src/TMC2100.h
@@ -13,8 +13,15 @@ class TMC2100 : public BasicStepperDriver {
 protected:
     short cf1_pin = PIN_UNCONNECTED;
     short cf2_pin = PIN_UNCONNECTED;
-    // Timing (set in constructors): tA STEP HIGH min 1us, tB STEP LOW min 1us,
-    // wakeup time nSLEEP inactive to STEP 1000us.
+    // Set timing requirements from TMC2100 datasheet
+    void initTiming(){
+        // tA STEP HIGH pulse duration, min value (1us)
+        step_high_min = 1;
+        // tB STEP LOW pulse duration, min value (1us)
+        step_low_min = 1;
+        // tWAKE wakeup time, nSLEEP inactive to STEP (1000us)
+        wakeup_time = 1000;
+    }
 
     // Get max microsteps supported by the device
     short getMaxMicrostep() override;


### PR DESCRIPTION
## Summary

The per-driver `step_high_min`/`step_low_min`/`wakeup_time` were declared `static const int` in each derived driver, shadowing the base class members. Since `BasicStepperDriver::nextAction()` and `enable()` bind statically to the base class, **every driver actually ran with a 1µs STEP pulse and the per-driver datasheet values were dead code**; `step_low_min` was never enforced and `wakeup_time` was never used at all.

Fixes #136 (Arduino Opta GPIO outpaces the driver input: users can now call `setMinStepPulse(8, 8)`).

## Changes

- `step_high_min`/`step_low_min`/`wakeup_time` are now protected `short` instance members; each driver assigns its datasheet values in all constructors (A4988 1/1/1000, DRV8825 2/2/1700, DRV8834 2/2/1000, DRV8880 1/1/1500, TMC2100 1/1/1000). DRV8880 uses 1µs, not the datasheet 0.47µs rounded down to 0, so fast ARM boards can't emit sub-datasheet pulses.
- New public API: `setMinStepPulse(high_us, low_us)`, `getMinStepPulseHigh()`, `getMinStepPulseLow()`. The low value is floored at 1 because `nextAction()` returning 0 signals end-of-move.
- `nextAction()` floors the STEP LOW interval at `step_low_min` (computed in unsigned form, no extra branch on the hot path).
- `enable()` waits the driver's `wakeup_time` (tWAKE) instead of a hardcoded 2µs; DRV8825 now correctly waits 1.7ms after wake.

## Behavior / performance impact

- DRV8825/DRV8834 STEP pulses widen from the erroneous 1µs to the datasheet 2µs, which slightly lowers the achievable max step rate on fast MCUs; on AVR the digitalWrite overhead already exceeded this so no practical change.
- `enable()` gains the datasheet wake delay (up to 1.7ms for DRV8825) — one-time cost per enable, prevents lost steps right after wake.
- RAM: +6 bytes per driver instance (three `short`s). Hot path instruction count unchanged (verified builds with `--warnings all`).

## Testing

- `make sim-test` (simavr, ATmega328P): 14/14 verdict lines match the golden baseline.
- `make BasicStepperDriver.hex / NonBlocking.hex / MultiAxis.hex TARGET=arduino:avr:uno`: clean, no warnings in library code.
- `pio ci --lib src --board esp32dev examples/BasicStepperDriver`: SUCCESS (32-bit target).

Agent: claude-opus-4-8 (Claude Code 2.1.153), reviewed and verified by claude-fable-5; max context and thinking level not exposed to the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)