### PR TITLE
Fix 16-bit int overflow in NonBlocking example move distance

### DIFF
--- a/examples/NonBlocking/NonBlocking.ino
+++ b/examples/NonBlocking/NonBlocking.ino
@@ -70,8 +70,10 @@ void setup() {
 
     // set the motor to move continuously for a reasonable time to hit the stopper
     // let's say 100 complete revolutions (arbitrary number)
-    stepper.startMove(100 * MOTOR_STEPS * MICROSTEPS);     // in microsteps
-    // stepper.startRotate(100 * 360);                     // or in degrees
+    // 100L keeps the arithmetic in long: with int it overflows 16-bit AVR ints
+    // (100*200*16 = 320000) and the motor would move the wrong way
+    stepper.startMove(100L * MOTOR_STEPS * MICROSTEPS);    // in microsteps
+    // stepper.startRotate(100L * 360);                    // or in degrees
 }
 
 void loop() {


### PR DESCRIPTION
## Summary

`examples/NonBlocking/NonBlocking.ino` computed the move distance as `100 * MOTOR_STEPS * MICROSTEPS` (= 320,000) in `int` arithmetic. On 16-bit AVR this overflows before promotion to `startMove()`'s `long` parameter, yielding a negative value that **reverses the move direction on Uno-class boards**. gcc was already flagging it with `-Woverflow`. Fixed with `100L` so the expression is evaluated as `long`; also fixed the commented-out `startRotate(100 * 360)` alternative (36,000 overflows too).

## Audit

Checked all other example sketches for arithmetic in `move()`/`startMove()`/`startRotate()`/`rotate()` arguments — everything else stays within `int` range (largest is UnitTest's `STEPS * microstep` = 200 × 128 = 25,600).

## Testing

`make NonBlocking.hex TARGET=arduino:avr:uno` builds clean with `--warnings all`; the previous `-Woverflow` warning is gone. Behavior on 32-bit targets is unchanged.

Agent: claude-fable-5 (Claude Code 2.1.153); max context and thinking level not exposed to the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)